### PR TITLE
feat: support watts and kilowats

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,17 @@ I recommend looking at the [Example usage section](#example-usage) to understand
 
 #### Card options
 
-| Name          | Type     |   Default    | Description                                                                                                                             |
-| ------------- | -------- | :----------: | --------------------------------------------------------------------------------------------------------------------------------------- |
-| type          | `string` | **required** | `custom:power-flow-card`.                                                                                                               |
-| entities      | `object` | **required** | One or more sensor entities, see [entities object](#entities-object) for additional entity options.                                     |
-| min_flow_rate | `number` |     .75      | Represents the fastest amount of time in seconds for a flow dot to travel from one end to the other, see [flow formula](#flow-formula). |
-| max_flow_rate | `number` |      6       | Represents the slowest amount of time in seconds for a flow dot to travel from one end to the other, see [flow formula](#flow-formula). |
+| Name           | Type     |   Default    | Description                                                                                                                             |
+| -------------- | -------- | :----------: | --------------------------------------------------------------------------------------------------------------------------------------- |
+| type           | `string` | **required** | `custom:power-flow-card`.                                                                                                               |
+| entities       | `object` | **required** | One or more sensor entities, see [entities object](#entities-object) for additional entity options.                                     |
+| min_flow_rate  | `number` |     .75      | Represents the fastest amount of time in seconds for a flow dot to travel from one end to the other, see [flow formula](#flow-formula). |
+| max_flow_rate  | `number` |      6       | Represents the slowest amount of time in seconds for a flow dot to travel from one end to the other, see [flow formula](#flow-formula). |
+| watt_threshold | `number` |      0       | The number of watts to display before converting to and displaying kilowatts. Setting of 0 will always display in kilowatts.            |
 
 #### Entities object
+
+All entites (except _battery_charge_) should have a `unit_of_measurement` attribute of W(watts) or kW(kilowatts).
 
 | Name           | Type                | Default      | Description                                                                                                                                                                                                     |
 | -------------- | :------------------ | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -66,7 +69,7 @@ I recommend looking at the [Example usage section](#example-usage) to understand
 
 #### Split entities
 
-Can be use with either Grid or Battery configuration
+Can be use with either Grid or Battery configuration. The same `unit_of_measurement` rule as above applies.
 
 | Name        | Type     | Default               | Description                                                                                       |
 | ----------- | -------- | --------------------- | ------------------------------------------------------------------------------------------------- |

--- a/src/power-flow-card-config.ts
+++ b/src/power-flow-card-config.ts
@@ -19,4 +19,5 @@ export interface PowerFlowCardConfig extends LovelaceCardConfig {
   };
   min_flow_rate: number;
   max_flow_rate: number;
+  watt_threshold: number;
 }

--- a/src/power-flow-card.ts
+++ b/src/power-flow-card.ts
@@ -40,6 +40,7 @@ export class PowerFlowCard extends LitElement {
       ...config,
       min_flow_rate: config.min_flow_rate ?? MIN_FLOW_RATE,
       max_flow_rate: config.max_flow_rate ?? MAX_FLOW_RATE,
+      watt_threshold: config.watt_threshold ?? 0,
     };
   }
 
@@ -67,6 +68,11 @@ export class PowerFlowCard extends LitElement {
     if (stateObj.attributes.unit_of_measurement === "W") return value;
     return value * 1000;
   };
+
+  private displayValue = (value: number) =>
+    value >= coerceNumber(this._config?.watt_threshold, 0)
+      ? `${roundValue(value / 1000, 1)} kW`
+      : `${value} W`;
 
   protected render(): TemplateResult {
     if (!this._config || !this.hass) {
@@ -178,9 +184,7 @@ export class PowerFlowCard extends LitElement {
                 >
                 <div class="circle">
                   <ha-svg-icon .path=${mdiSolarPower}></ha-svg-icon>
-                  <span class="solar">
-                    ${roundValue(solarState ?? 0, 1)} kW</span
-                  >
+                  <span class="solar"> ${this.displayValue(solarState)}</span>
                 </div>
               </div>`
             : html``}
@@ -194,7 +198,7 @@ export class PowerFlowCard extends LitElement {
                         class="small"
                         .path=${mdiArrowLeft}
                       ></ha-svg-icon
-                      >${roundValue(solarToGrid, 1)} kW
+                      >${this.displayValue(solarToGrid)}
                     </span>`
                   : null}
                 <span class="consumption">
@@ -202,7 +206,7 @@ export class PowerFlowCard extends LitElement {
                     class="small"
                     .path=${mdiArrowRight}
                   ></ha-svg-icon
-                  >${roundValue(gridToHome, 1)} kW
+                  >${this.displayValue(gridToHome)}
                 </span>
               </div>
               <span class="label"
@@ -218,7 +222,7 @@ export class PowerFlowCard extends LitElement {
                 })}"
               >
                 <ha-svg-icon .path=${mdiHome}></ha-svg-icon>
-                ${roundValue(homeConsumption, 1)} kW
+                ${this.displayValue(homeConsumption)}
                 ${homeSolarCircumference !== undefined
                   ? html`<svg>
                       ${homeSolarCircumference !== undefined
@@ -298,14 +302,14 @@ export class PowerFlowCard extends LitElement {
                         class="small"
                         .path=${mdiArrowDown}
                       ></ha-svg-icon
-                      >${roundValue(solarToBattery, 1)} kW</span
+                      >${this.displayValue(solarToBattery)}</span
                     >
                     <span class="battery-out">
                       <ha-svg-icon
                         class="small"
                         .path=${mdiArrowUp}
                       ></ha-svg-icon
-                      >${roundValue(batteryToHome, 1)} kW</span
+                      >${this.displayValue(batteryToHome)}</span
                     >
                   </div>
                   <span class="label"


### PR DESCRIPTION
- Entity states can be supplied in either kilowatts or watts
- New configuration option watt_threshold displays watts when below and kilowatts when above, defaults to 0 which always shows kilowatts

Closes #14 